### PR TITLE
fix preprocessing method without textpipe

### DIFF
--- a/canosp2020/language_dector.py
+++ b/canosp2020/language_dector.py
@@ -1,0 +1,41 @@
+from spacy.tokens import Doc
+from langdetect import detect_langs
+from langdetect.lang_detect_exception import LangDetectException
+
+
+def get_language(text, cld_results=None):
+    if cld_results is None:
+        cld_results = detect_language(text)
+    return cld_results["language"]
+
+
+def get_score(text, cld_results=None):
+    if cld_results is None:
+        cld_results = detect_language(text)
+    return cld_results["score"]
+
+
+def detect_language(text):
+    try:
+        detected_language = detect_langs(text.text)[0]
+        return {"language": str(detected_language.lang), "score": float(detected_language.prob)}
+    except LangDetectException:
+        return {"language": "UNKNOWN", "score": 0.0}
+
+
+class LanguageDetector(object):
+
+    name = "cld"
+
+    def __init__(self, attrs=("language", "language_score")):
+        self._language, self._score = attrs
+        Doc.set_extension(self._language, getter=get_language)
+        Doc.set_extension(self._score, getter=get_score)
+
+    def __call__(self, doc):
+        """Apply the language detector as a pipeline component."""
+        # Make a single call to the language detector and cache the result.
+        cld_results = detect_language(doc)
+        doc._.set(self._language, get_language(doc, cld_results))
+        doc._.set(self._score, get_score(doc, cld_results))
+        return doc

--- a/canosp2020/preprocessing.py
+++ b/canosp2020/preprocessing.py
@@ -1,79 +1,162 @@
 import re
+import multiprocessing
 import spacy
-from textpipe import doc, pipeline
-from textpipe.doc import Doc
-from typing import Callable
+import warnings
+import numpy as np
+import pandas as pd
+
+from typing import List
+from requests_html import HTML
+from pandas import DataFrame
+from tqdm import tqdm
+
+from .language_dector import LanguageDetector
+
+# Filter out annoying bs4 warning about URL in the text
+warnings.filterwarnings("ignore", category=UserWarning, module="bs4")
+
+
+def parallelize_dataframe(df, func, n_cores=multiprocessing.cpu_count()):
+    df_split = np.array_split(df, n_cores)
+    pool = multiprocessing.Pool(n_cores)
+    df = pd.concat(pool.map(func, df_split))
+    pool.close()
+    pool.join()
+    return df
+
+
+def apply_clean_text(df):
+    df.loc[:, "content"] = df["content"].apply(clean_text)
+    df.loc[:, "title"] = df["title"].apply(clean_text)
+    return df
+
+
+def clean_text(text):
+    if not text:
+        return text
+    try:
+        text = HTML(html=text).text
+    except Exception as e:
+        print(e)
+        print(text)
+    text = re.sub(r"http[s]?://\S+", "", text)
+    text = re.sub(r"…", "...", text)
+    text = re.sub(r"[`‘’‛⸂⸃⸌⸍⸜⸝]", "'", text)
+    text = re.sub(r"[„“]|(\'\')|(,,)", '"', text)
+    text = re.sub(r"\s+", " ", text).strip()
+    text = text.lower()
+
+    return text
+
+
+def parallelize_spacy_docs(docs, df, func, n_cores=multiprocessing.cpu_count()):
+    docs_split = np.array_split(docs, n_cores)
+    df_split = np.array_split(df, n_cores)
+    pool = multiprocessing.Pool(n_cores)
+    output_df = pd.concat(pool.map(func, zip(docs_split, df_split)))
+    pool.close()
+    pool.join()
+    return output_df
+
+
+def apply_spacy_docs(inputs):
+    docs, df = inputs
+    output_content = []
+    output_lang = []
+    for index, doc in enumerate(docs):
+        lang = doc._.language
+        if lang == "en":
+            output_content.append(" ".join([token.lemma_ for token in doc if not (token.is_punct or token.is_stop)]))
+        else:
+            output_content.append(doc.text)
+        output_lang.append(lang)
+    df["content"] = output_content
+    df["lang"] = output_lang
+
+    return df
 
 
 class Preprocess:
     """
-    Preprocess text documents with textpipe and sPacy.
+    Preprocess text documents with spacy.
 
-    >>> preprocessor = Preprocess()
-    >>> preprocessor.preprocess(<p>hello world! Liking</p>)
-    hello world like
+    :param csv_file: Path to input csv file
+    :param stopwords: A list of custom stopwords
+
+    >>> preprocessor = Preprocessor("data/tickets.csv")
+    >>> preprocessor.preprocess_tickets()
     """
 
-    def __init__(self, custom_op: Callable = None):
-        """
-        :custom_op: See below _custom_op as example
-        """
-        self._pipeline = pipeline.Pipeline([])
-        if not custom_op:
-            self._pipeline.register_operation("CustomOp", self._custom_op)
-            self._pipeline.steps.append(("CustomOp", {}))
-        else:
-            self._pipeline.register_operation("CustomOp", custom_op)
-            self._pipeline.steps.append(("CustomOp", {}))
+    def __init__(self, csv_file: str, stopwords: List[str] = None):
+        self._df = pd.read_csv(csv_file)
+        self._nlp = spacy.load("en_core_web_sm")
 
-    @staticmethod
-    def _custom_op(doc: doc.Doc, context=None, settings=None, **kwargs):
+        if stopwords:
+            self._nlp.Defaults.stop_words |= set(stopwords)
+
+    def preprocess_tickets(self):
         """
-        Default custom textpipe operation
+        Preprocess ticket title and content
+
+        Apply the following
             - Strip HTML tags
-            - Lemmatization
+            - Strip whitespaces
+            - Remove dots
+            - Remove http[s] url suffix
+            - Remove punctuation
             - Remove stop words
-            - Remove punctuations
-        If encounter unsupported input lanauage, return None
+            - Lemmatize
+
+        Overwrite preprocessed text back to original column
+        in the dataframe.
+
+        Add new `title_content` column column
+        which consists content from both title and content
+
+        Add new `lang` column.
         """
+        import time
+
+        language_detector = LanguageDetector()
+        self._nlp.add_pipe(language_detector, name="language_detector")
+
+        # Add new lang column with default value of `en`
+        start_time = time.time()
+        self._df = parallelize_dataframe(self._df, apply_clean_text)
+        print(f"Pre-preprocess (content): {time.time() - start_time} sec")
+
+        # Run spacy pipeline on `content` column
+        start_time = time.time()
+        content_docs = list(
+            self._nlp.pipe(
+                self._df["content"], disable=["tagger", "ner", "textcat"], n_process=multiprocessing.cpu_count()
+            )
+        )
+        print(f"Spacy pipe (content): {time.time() - start_time} sec")
+
+        # Remove punct, stopwords, lemmatizer on `content`
+        start_time = time.time()
+        self._df = parallelize_spacy_docs(content_docs, self._df, apply_spacy_docs)
+        print(f"Final cleanup (content): {time.time() - start_time} sec")
+
+        # Run spacy pipeline on `title` column
+        self._nlp.remove_pipe("language_detector")
+        title_docs = list(
+            self._nlp.pipe(
+                self._df["title"], disable=["parser", "ner", "textcat"], n_process=multiprocessing.cpu_count()
+            )
+        )
+
+        # Remove punct, stopwords, lemmatizer on `content`
+        start_time = time.time()
+        self._df.loc[:, "title"] = [
+            " ".join([token.lemma_ for token in doc if not (token.is_punct or token.is_stop)]) for doc in title_docs
+        ]
+        print(f"Final cleanup (title): {time.time() - start_time} sec")
+
+        # Merge `title` and `content` column into a new column
+        self._df["title_content"] = self._df["title"] + " " + self._df["content"]
+
+    def preprocess_tags(self):
         # TODO
-        # add multi lang/lm support
-        # return None for now
-        if doc.detect_language()[1] != "en":
-            # do some manual regex preprocessing and re-try
-            text = re.sub("</?.*?>", " <> ", doc.raw)  # remove tags
-            text = text.strip()  # remove whitespaces in the front and the end
-            text = re.sub("(\\d|\\W)+", " ", text)  # remove special chars and digits
-            text = re.sub(r'[.|,|)|(|\|/|?|!|\'|"|#]', r" ", text)  # remove any punctuation
-            doc = Doc(raw=text)
-            if doc.detect_language()[1] != "en":
-                print("Cannot determine input language.")
-                return None
-
-        spacy_doc = doc._spacy_doc
-        spacy_nlp = doc._spacy_nlps["en"][None]
-
-        # default clean_text method, strip HTML tags and lower case
-        raw_text = doc.clean.lower()
-
-        # apply lemmatization
-        # remove punct and stop words
-        spacy_doc = spacy_nlp(raw_text)
-        spacy_doc = spacy_nlp(" ".join([token.lemma_ for token in spacy_doc if not (token.is_punct or token.is_stop)]))
-
-        return spacy_doc
-
-    def preprocess(self, text) -> spacy.tokens.doc.Doc:
-        try:
-            text = self._pipeline(text)
-            return text["CustomOp"]
-        except Exception as e:
-            print(e)
-            return None
-
-
-if __name__ == "__main__":
-    sample_text = "<p>Hello World! This is a sample text.</p>"
-    preprocessor = Preprocess()
-    processed_text = preprocessor.preprocess(sample_text)
-    print(processed_text)
+        pass


### PR DESCRIPTION
Using plain `spacy` and `requests-html` library to preprocess

- Multiprocessing in batches
- At least 4x faster than the old solution

But you should properly just used this instead https://drive.google.com/open?id=1hVZ83sIKh_uKJOYwuPnjI1EM1HRUi_3Y

It used to take a night to finish...

```
Pre-preprocess (content): 114.28022003173828 sec
Spacy pipe (content): 947.8442788124084 sec
Final cleanup (content): 760.0363528728485 sec
Final cleanup (title): 4.898693084716797 sec
```