### PR TITLE
Only run the Conda workflow when necessary

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,9 +1,9 @@
 name: Setup Anaconda environment
 
 on:
-  pull_request:
-    branches:
-    - '*'
+  push:
+    paths:
+      - '.github/workflows/conda.yml'
 
 jobs:
   example-1:
@@ -16,8 +16,6 @@ jobs:
         python-version: [3.7]
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: will-conda-migration
       - uses: goanpeca/setup-miniconda@v1
         with:
           auto-update-conda: true

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - '.github/workflows/conda.yml'
+      - 'environment.yml'
 
 jobs:
   example-1:


### PR DESCRIPTION
* The Conda workflow will only run when a change to `.github/workflows/conda.yml` or `environment.yml` is pushed.