### PR TITLE
add dtype casting when initializing

### DIFF
--- a/canosp2020/preprocessing.py
+++ b/canosp2020/preprocessing.py
@@ -91,6 +91,9 @@ class Preprocess:
         self._df = pd.read_csv(csv_file)
         self._nlp = spacy.load("en_core_web_sm")
 
+        self._df["title"] = self._df["title"].astype(str)
+        self._df["content"] = self._df["content"].astype(str)
+
         if stopwords:
             self._nlp.Defaults.stop_words |= set(stopwords)
 


### PR DESCRIPTION
Without casting, Pandas treat those columns as non-string type.

Fix issue @konantian encountered.